### PR TITLE
check: updating the failure alert based on the retry

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ systemd_timer_documentation: 'https://github.com/status-im/infra-role-systemd-ti
 systemd_timer_enabled: true
 systemd_timer_start_on_boot: false
 systemd_timer_start_on_creation: true
-systemd_timer_timeout_sec: 60
+systemd_timer_timeout_sec: 300
 systemd_timer_work_dir: '/'
 systemd_timer_state_dir_create: false
 systemd_timer_state_dir: '{{ systemd_timer_name }}'
@@ -49,7 +49,13 @@ systemd_timer_consul_service_id: '{{ systemd_timer_consul_service_name }}'
 systemd_timer_consul_check_path: '/usr/local/bin/check-timer-status.sh'
 systemd_timer_consul_address: '{{ ansible_local.wireguard.vpn_ip }}'
 systemd_timer_consul_warning: false
-
+systemd_timer_consul_success_before_passing: 0
+systemd_timer_consul_check_interval: 30
+# Default value if the Timer doesn't restart else value based on the timeout divided by consul interval check
+systemd_timer_failure_success_before_warning: '{{ 1 if systemd_timer_restart == "no" else (systemd_timer_timeout_sec / systemd_timer_consul_check_interval ) | int  }}'
+systemd_timer_duration_with_restarts: '{{ (systemd_timer_restart_retries * (systemd_timer_restart_delay + systemd_timer_timeout_sec)) }}'
+# Default value if the Timer doesn't restart else value based on the number of restart and delays by consul interval check
+systemd_timer_failure_success_before_critical: '{{ 2 if systemd_timer_restart == "no" else ( systemd_timer_duration_with_restarts | int / systemd_timer_consul_check_interval ) |int  }}'
 # Tags
 systemd_timer_consul_extra_tags: []
 systemd_timer_consul_default_tags: ['timer']

--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -9,6 +9,9 @@
   include_role: name=consul-service
   vars:
     consul_config_name: '{{ systemd_timer_consul_service_id }}'
+    consul_default_success_before_passing:   '{{ systemd_timer_consul_success_before_passing }}'
+    consul_default_failures_before_warning:  '{{ systemd_timer_failure_success_before_warning }}'
+    consul_default_failures_before_critical: '{{ systemd_timer_failure_success_before_critical }}'
     consul_services:
       - id:   '{{ systemd_timer_consul_service_id }}'
         name: '{{ systemd_timer_consul_service_name }}'
@@ -19,6 +22,7 @@
           - id: '{{ systemd_timer_consul_service_id }}-check'
             name: 'Systemd Timer Healthcheck'
             notes: '{{ systemd_timer_description }}'
+            interval: '{{ systemd_timer_consul_check_interval | string + "s" }}'
             type: 'script'
             script: >-
               {{ systemd_timer_consul_check_path }}


### PR DESCRIPTION
The divided by 30 is based from the default value of consul interval check : https://github.com/status-im/infra-role-consul-service/blob/master/templates/service.json.j2#L58